### PR TITLE
connect: Use device provided to class

### DIFF
--- a/pyanova_nano/client.py
+++ b/pyanova_nano/client.py
@@ -88,10 +88,13 @@ class PyAnova:
                 discover the device.
 
         """
-        if not device:
+        if device:
+            self._device = device
+
+        if not self._device:
             await self.discover(connect=True, list_all=False)
         else:
-            await self._connect(device)
+            await self._connect(self._device)
 
         await self._connected
 


### PR DESCRIPTION
Don't discover devices if the class was initialized with a device.

Closes #7 