### PR TITLE
13 Esphome backend compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2024-10-03
+- Fix incompatibility with ESPHome Bluetooth Proxies.
+  
+  Subscribe callback only once to 'read' characteristics.
+  Avoid sharing result array and future across subsequent calls.
+  
+- Add debug log statements
+- Retry connection attempt
+
 ## [0.2.1] - 2024-09-29
 ### Changed
 - Fix BleakError raised on subsequent read commands on ``bleak-esphome`` backend.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import asyncio
 from pyanova_nano import PyAnova
 
 
-async def get_unit():
+async def get_timer():
     client = PyAnova()
     await client.connect()
 
@@ -55,7 +55,7 @@ async def get_unit():
     await client.disconnect()
 
 
-asyncio.run(get_unit())
+asyncio.run(get_timer())
 ```
 
 ### Manual connection

--- a/pyanova_nano/client.py
+++ b/pyanova_nano/client.py
@@ -172,6 +172,7 @@ class PyAnova:
                     ble_device_callback=None,
                     max_attempts=5,
                     disconnected_callback=self._on_disconnect,
+                    timeout_seconds=timeout_seconds,
                 )
 
             if not self._client.is_connected:

--- a/pyanova_nano/client.py
+++ b/pyanova_nano/client.py
@@ -14,6 +14,7 @@ from bleak import BLEDevice
 from bleak import BleakClient
 from bleak import BleakError
 from bleak import BleakScanner
+from bleak_retry_connector import establish_connection, BleakClientWithServiceCache
 from google.protobuf.message import DecodeError
 
 from pyanova_nano.commands import COMMANDS_MAP
@@ -57,7 +58,7 @@ class PyAnova:
     CHARACTERISTICS_ASYNC = "0e140003-0af1-4582-a242-773e63054c68"
 
     _CONNECT_TIMEOUT_SEC = 10
-    _RX_DATA_TIMEOUT_SEC = 3
+    _READ_DATA_TIMEOUT_SEC = 10
 
     def __init__(
         self,
@@ -359,7 +360,7 @@ class PyAnova:
             return
 
         try:
-            async with asyncio.timeout(self._RX_DATA_TIMEOUT_SEC):
+            async with asyncio.timeout(self._READ_DATA_TIMEOUT_SEC):
                 await data
         finally:
             self._command_lock.release()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyanova-nano"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   { name="Mitja Muller-Jend", email="mitja.muller-jend+github@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "bleak >= 0.19, < 1",
-    "bleak-retry-connector >= 3.5, < 1",
+    "bleak-retry-connector >= 3.5, < 4",
     "protobuf >= 4, < 5",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "bleak >= 0.19, < 1",
+    "bleak-retry-connector >= 3.5, < 1",
     "protobuf >= 4, < 5",
 ]
 


### PR DESCRIPTION
On the ESPHome BT proxy backend `bleak_esphome` you cannot subscribe to the same characteristics twice, while on the windows backend you can.
Since the re-subscription fails, the callback kept adding the received raw data to the same bytearray - creating invalid arrays that cannot be decoded. Additionally the future was shared across read command calls, thus being already marked completed before we even got new data.

With this change:
- Only subscribe once
- resulting bytearray is cleared before each read call.